### PR TITLE
Adds default timeouts to RestCarrier on GuzzleClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ Or If you just want to run the examples contained in this project run "composer 
 
 Create an object with the configuration required for that instance
 
-```
+```php 
 $placetopay = new Dnetix\Redirection\PlacetoPay([
     'login' => 'YOUR_LOGIN',
     'tranKey' => 'YOUR_TRANKEY',
     'url' => 'https://THE_BASE_URL_TO_POINT_AT',
+    'rest' => [
+        'timeout' => 45, // (optional) 15 by default
+        'connect_timeout' => 30, // (optional) 5 by default
+    ]
 ]);
 ```
 

--- a/src/Carrier/RestCarrier.php
+++ b/src/Carrier/RestCarrier.php
@@ -38,7 +38,10 @@ class RestCarrier extends Carrier
     private function makeRequest($method, $url, $arguments)
     {
         try {
-            $client = new Client();
+            $client = new Client([
+                'timeout' => $this->config['timeout']?? 15,
+                'connect_timeout' => $this->config['connect_timeout']?? 5,
+            ]);
             $data = array_merge($arguments, [
                 'auth' => $this->authentication()->asArray(),
             ]);


### PR DESCRIPTION
Adds defaults to RestCarrier on GuzzleClient

- `timeout` = 15
- `connect_timeout` = 5

Values can be overwritten by passing config options
