### PR TITLE
feat: adds support for `metadata` and `provider` properties.

### DIFF
--- a/src/Message/CollectRequest.php
+++ b/src/Message/CollectRequest.php
@@ -11,11 +11,18 @@ class CollectRequest extends RedirectRequest
     protected string $returnUrl = '';
     protected string $ipAddress = '';
     protected string $userAgent = '';
+    protected ?string $provider = null;
 
     public function __construct(array $data = [])
     {
         parent::__construct($data);
         $this->loadEntity($data['instrument'], 'instrument', Instrument::class);
+        $this->provider = $data['provider'] ?? null;
+    }
+
+    public function provider(): ?string
+    {
+        return $this->provider;
     }
 
     public function instrument(): Instrument
@@ -27,6 +34,7 @@ class CollectRequest extends RedirectRequest
     {
         return array_merge(parent::toArray(), [
             'instrument' => $this->instrument() ? $this->instrument()->toArray() : null,
+            'provider' => $this->provider(),
         ]);
     }
 }

--- a/src/Message/RedirectRequest.php
+++ b/src/Message/RedirectRequest.php
@@ -27,6 +27,8 @@ class RedirectRequest extends Entity
     protected bool $skipResult = false;
     protected bool $noBuyerFill = false;
 
+    protected array $metadata = [];
+
     public function __construct($data = [])
     {
         // Setting the default values
@@ -48,6 +50,8 @@ class RedirectRequest extends Entity
         if (isset($data['fields'])) {
             $this->setFields($data['fields']);
         }
+
+        $this->metadata = $data['metadata'] ?? [];
     }
 
     public function locale(): string
@@ -177,6 +181,11 @@ class RedirectRequest extends Entity
         return filter_var($this->noBuyerFill, FILTER_VALIDATE_BOOLEAN);
     }
 
+    public function metadata(): array
+    {
+        return $this->metadata;
+    }
+
     public function toArray(): array
     {
         return $this->arrayFilter([
@@ -195,6 +204,7 @@ class RedirectRequest extends Entity
             'captureAddress' => $this->captureAddress(),
             'skipResult' => $this->skipResult(),
             'noBuyerFill' => $this->noBuyerFill(),
+            'metadata' => $this->metadata(),
         ]);
     }
 }

--- a/tests/Messages/CollectRequestTest.php
+++ b/tests/Messages/CollectRequestTest.php
@@ -43,6 +43,10 @@ class CollectRequestTest extends BaseTestCase
             'captureAddress' => false,
             'skipResult' => false,
             'noBuyerFill' => false,
+            'provider' => 'PROVIDER',
+            'metadata' => [
+                "initiatorIndicator" =>  "AGENT"
+            ]
         ];
         $request = new CollectRequest($data);
 
@@ -53,5 +57,8 @@ class CollectRequestTest extends BaseTestCase
 
         $this->assertEquals($data['instrument'], $request->instrument()->toArray());
         $this->assertEquals($data, $request->toArray());
+        $this->assertEquals($data['metadata'], $request->metadata());
+        $this->assertEquals($data['provider'], $request->provider());
+
     }
 }

--- a/tests/Messages/RedirectRequestTest.php
+++ b/tests/Messages/RedirectRequestTest.php
@@ -103,6 +103,9 @@ class RedirectRequestTest extends BaseTestCase
             'noBuyerFill' => true,
             'captureAddress' => true,
             'paymentMethod' => 'CR_VS,_ATH_',
+            'metadata' => [
+                "initiatorIndicator" =>  "AGENT"
+            ],
         ];
         $request = new RedirectRequest($data);
 
@@ -112,6 +115,7 @@ class RedirectRequestTest extends BaseTestCase
         $this->assertTrue($request->payment()->allowPartial());
         $this->assertEquals($data['returnUrl'], $request->returnUrl());
         $this->assertEquals($data['cancelUrl'], $request->cancelUrl());
+        $this->assertEquals($data['metadata'], $request->metadata());
 
         $this->assertEquals($data, $request->toArray());
     }


### PR DESCRIPTION
Adds support for new properties based on the [public documentation](https://docs.placetopay.dev/checkout/api/reference/session#create-a-session):

• **RedirectRequest.metadata**:
A key-value structure used to send additional information and define specific behaviors during session processing.

• **CollectRequest.provider**:
Supports specifying the provider to be used in the transaction.