### PR TITLE
Feature/fix deprecations in PHP 8.2

### DIFF
--- a/.github/workflows/.ci-php.yml
+++ b/.github/workflows/.ci-php.yml
@@ -11,6 +11,8 @@ jobs:
           - "8.0"
           - "8.1"
           - "8.2"
+          - "8.3"
+          - "8.4"
         dependency-versions:
           - "lowest"
           - "highest"

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -14,7 +14,14 @@ $rules = [
     'blank_line_before_statement' => [
         'statements' => ['declare'],
     ],
-    'braces' => true,
+    'single_space_around_construct' => true,
+    'control_structure_braces' => true,
+    'control_structure_continuation_position' => true,
+    'declare_parentheses' => true,
+    'no_multiple_statements_per_line' => true,
+    'braces_position' => true,
+    'statement_indentation' => true,
+    'no_extra_blank_lines' => true,
     'cast_spaces' => [
         'space' => 'none',
     ],
@@ -27,7 +34,7 @@ $rules = [
     'encoding' => true,
     'full_opening_tag' => true,
     'function_declaration' => true,
-    'function_typehint_space' => true,
+    'type_declaration_spaces' => true,
     'single_line_comment_style' => [
         'comment_types' => ['hash'],
     ],
@@ -59,8 +66,8 @@ $rules = [
     'no_singleline_whitespace_before_semicolons' => true,
     'no_spaces_after_function_name' => true,
     'no_spaces_around_offset' => true,
-    'no_spaces_inside_parenthesis' => true,
-    'no_trailing_comma_in_list_call' => true,
+    'spaces_inside_parentheses' => false,
+    'no_trailing_comma_in_singleline' => true,
     'no_trailing_whitespace' => true,
     'no_trailing_whitespace_in_comment' => true,
     'no_unneeded_control_parentheses' => true,
@@ -109,8 +116,7 @@ $rules = [
     'logical_operators' => true,
     'short_scalar_cast' => true,
     'no_unset_cast' => true,
-    'no_trailing_comma_in_singleline_array' => true,
-    'single_blank_line_before_namespace' => true,
+    'blank_lines_before_namespace' => true,
 ];
 
 $finder = Finder::create()

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,5 +14,9 @@
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <server name="PHPUNIT_ERROR_HANDLER" value="PHPUnit\Util\ErrorHandler::handleDeprecation"/>
+  </php>
   <logging/>
 </phpunit>

--- a/src/Entities/Amount.php
+++ b/src/Entities/Amount.php
@@ -13,8 +13,23 @@ class Amount extends AmountBase
      */
     protected array $details = [];
 
-    protected $tip;
-    protected $insurance;
+    /**
+     * Details Available:
+     * @var float
+     * @see https://docs.placetopay.dev/checkout/tax-details#amount-details
+     */
+    protected float $discount;
+    protected float $additional;
+    protected float $vatDevolutionBase;
+    protected float $shipping;
+    protected float $handlingFee;
+    protected float $insurance;
+    protected float $giftWrap;
+    protected float $subtotal;
+    protected float $fee;
+    protected float $tip;
+    protected float $airline;
+    protected float $interest;
 
     public function __construct($data = [])
     {

--- a/tests/Entities/AmountTest.php
+++ b/tests/Entities/AmountTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Entities;
 
 use Dnetix\Redirection\Entities\Amount;
-use Dnetix\Redirection\Exceptions\PlacetoPayException;
 use Tests\BaseTestCase;
 
 class AmountTest extends BaseTestCase

--- a/tests/Entities/AmountTest.php
+++ b/tests/Entities/AmountTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Entities;
+
+use Dnetix\Redirection\Entities\Amount;
+use Dnetix\Redirection\Exceptions\PlacetoPayException;
+use Tests\BaseTestCase;
+
+class AmountTest extends BaseTestCase
+{
+    public function testItWorksWithTaxes()
+    {
+        $amount = new Amount([
+            'taxes' => $taxes = [
+                [
+                    'kind' => 'valueAddedTax',
+                    'amount' => 100,
+                    'base' => 10,
+                ],
+                [
+                    'kind' => 'exciseDuty',
+                    'amount' => 200,
+                    'base' => 20,
+                ],
+                [
+                    'kind' => 'ice',
+                    'amount' => 300,
+                    'base' => 30,
+                ],
+                [
+                    'kind' => 'airportTax',
+                    'amount' => 400,
+                    'base' => 40,
+                ],
+                [
+                    'kind' => 'stateTax',
+                    'amount' => 500,
+                    'base' => 50,
+                ],
+                [
+                    'kind' => 'municipalTax',
+                    'amount' => 600,
+                    'base' => 60,
+                ],
+                [
+                    'kind' => 'reducedStateTax',
+                    'amount' => 700,
+                    'base' => 70,
+                ],
+            ],
+        ]);
+
+        $this->assertCount(7, $amount->taxes());
+
+        foreach ($taxes as $i => $tax) {
+            $this->assertInstanceOf('Dnetix\Redirection\Entities\TaxDetail', $amount->taxes()[$i]);
+            $this->assertSame($tax['kind'], $amount->taxes()[$i]->kind());
+            $this->assertSame((float)$tax['amount'], $amount->taxes()[$i]->amount());
+            $this->assertSame((float)$tax['base'], $amount->taxes()[$i]->base());
+        }
+    }
+
+    public function testItWorksWithDetails()
+    {
+        $amount = new Amount([
+            'details' => $details = [
+                [
+                    'kind' => 'discount',
+                    'amount' => 10,
+                ],
+                [
+                    'kind' => 'additional',
+                    'amount' => 20,
+                ],
+                [
+                    'kind' => 'vatDevolutionBase',
+                    'amount' => 30,
+                ],
+                [
+                    'kind' => 'shipping',
+                    'amount' => 40,
+                ],
+                [
+                    'kind' => 'handlingFee',
+                    'amount' => 50,
+                ],
+                [
+                    'kind' => 'insurance',
+                    'amount' => 60,
+                ],
+                [
+                    'kind' => 'giftWrap',
+                    'amount' => 70,
+                ],
+                [
+                    'kind' => 'subtotal',
+                    'amount' => 80,
+                ],
+                [
+                    'kind' => 'fee',
+                    'amount' => 90,
+                ],
+                [
+                    'kind' => 'tip',
+                    'amount' => 100,
+                ],
+                [
+                    'kind' => 'airline',
+                    'amount' => 110,
+                ],
+                [
+                    'kind' => 'interest',
+                    'amount' => 120,
+                ],
+            ],
+        ]);
+
+        $this->assertCount(12, $amount->details());
+
+        foreach ($details as $i => $detail) {
+            $this->assertInstanceOf('Dnetix\Redirection\Entities\AmountDetail', $amount->details()[$i]);
+            $this->assertSame($detail['kind'], $amount->details()[$i]->kind());
+            $this->assertSame((float)$detail['amount'], $amount->details()[$i]->amount());
+        }
+    }
+}

--- a/tests/Messages/CollectRequestTest.php
+++ b/tests/Messages/CollectRequestTest.php
@@ -45,8 +45,8 @@ class CollectRequestTest extends BaseTestCase
             'noBuyerFill' => false,
             'provider' => 'PROVIDER',
             'metadata' => [
-                "initiatorIndicator" =>  "AGENT"
-            ]
+                'initiatorIndicator' =>  'AGENT',
+            ],
         ];
         $request = new CollectRequest($data);
 
@@ -59,6 +59,5 @@ class CollectRequestTest extends BaseTestCase
         $this->assertEquals($data, $request->toArray());
         $this->assertEquals($data['metadata'], $request->metadata());
         $this->assertEquals($data['provider'], $request->provider());
-
     }
 }

--- a/tests/Messages/RedirectRequestTest.php
+++ b/tests/Messages/RedirectRequestTest.php
@@ -104,7 +104,7 @@ class RedirectRequestTest extends BaseTestCase
             'captureAddress' => true,
             'paymentMethod' => 'CR_VS,_ATH_',
             'metadata' => [
-                "initiatorIndicator" =>  "AGENT"
+                'initiatorIndicator' =>  'AGENT',
             ],
         ];
         $request = new RedirectRequest($data);


### PR DESCRIPTION
Fixed deprecations in PHP 8.2 related with: _Creation of dynamic property_

[Deprecation](https://www.php.net/manual/en/migration82.deprecated.php)

- fix: avoid deprecations in PHP 8.2 related with: Creation of dynamic property
- tests: Enable deprecatiosn as errors in PHPUnit
- ci: enable PHP 8.3 and 8.4 versions